### PR TITLE
%o specifier is not in the ft_printf project anymore and warning is caused when compiling.

### DIFF
--- a/check_leaks.c
+++ b/check_leaks.c
@@ -6,7 +6,7 @@
 /*   By: cacharle <marvin@42.fr>                    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2020/02/06 18:14:36 by cacharle          #+#    #+#             */
-/*   Updated: 2020/02/06 18:14:37 by cacharle         ###   ########.fr       */
+/*   Updated: 2020/07/08 18:14:37 by ykoh             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -275,7 +275,6 @@ int main()
 	ft_printf("%hhllo", 42);
 	ft_printf("%llho", 42);
 	ft_printf("%lllo", 42);
-	ft_printf("%-o", 42);
 	ft_printf("%Lu", 42);
 	ft_printf("%#u", 42);
 	ft_printf("%+u", 42);

--- a/header.h
+++ b/header.h
@@ -6,7 +6,7 @@
 /*   By: cacharle <marvin@42.fr>                    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2020/02/06 18:13:32 by cacharle          #+#    #+#             */
-/*   Updated: 2020/04/02 20:49:26 by charles          ###   ########.fr       */
+/*   Updated: 2020/07/08 18:16:16 by ykoh             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,6 +20,7 @@
 # include <unistd.h>
 # include <string.h>
 # include <stdbool.h>
+# include <signal.h>
 
 int pid;
 int pid2;

--- a/tests/pft_tests.c
+++ b/tests/pft_tests.c
@@ -6,7 +6,7 @@
 /*   By: cacharle <marvin@42.fr>                    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2020/02/06 18:15:10 by cacharle          #+#    #+#             */
-/*   Updated: 2020/04/02 20:46:35 by charles          ###   ########.fr       */
+/*   Updated: 2020/07/08 18:15:02 by ykoh             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -76,7 +76,6 @@ void test_pft_nocrash(void)
 //	ASSERT_PRINTF("%hhllo", 42);
 //	ASSERT_PRINTF("%llho", 42);
 //	ASSERT_PRINTF("%lllo", 42);
-	ASSERT_PRINTF("%-o", 42);
 //////	ASSERT_PRINTF("%Lu", 42);
 //	ASSERT_PRINTF("%#u", 42);
 //	ASSERT_PRINTF("%+u", 42);


### PR DESCRIPTION
%o specifier is not in the ft_printf project anymore and warning is caused when compiling.

I delete %o test and add signal.h header.